### PR TITLE
fix: add fallbacks for VIP-specific code

### DIFF
--- a/src/includes/classes/class-alerts.php
+++ b/src/includes/classes/class-alerts.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Automattic\VIP\Search;
+
+class Alerts {
+	private static $instance = null;
+
+	public static function instance() {
+		if ( null === self::$instance ) {
+			self::$instance = new static();
+		}
+
+		return self::$instance;
+	}
+
+	protected static function clear_instance() {
+		self::$instance = null;
+	}
+
+	public function send_to_chat( $channel_or_user, $message, $level = 0, $kind = '', $interval = 1 ) {
+		if ( class_exists( \Automattic\VIP\Utils\Alerts::class ) ) {
+			return \Automattic\VIP\Utils\Alerts::chat( $channel_or_user, $message, $level, $kind, $interval );
+		}
+
+		return false;
+	}
+
+	public static function chat( $channel_or_user, $message, $level = 0, $kind = '', $interval = 1 ) {
+		return self::instance()->send_to_chat( $channel_or_user, $message, $level, $kind, $interval );
+	}
+}

--- a/src/includes/classes/class-healthjob.php
+++ b/src/includes/classes/class-healthjob.php
@@ -3,7 +3,6 @@
 namespace Automattic\VIP\Search;
 
 use Automattic\VIP\Search\Health;
-use Automattic\VIP\Utils\Alerts;
 
 require_once __DIR__ . '/class-health.php';
 
@@ -119,7 +118,7 @@ class HealthJob {
 			return;
 		}
 
-		\Automattic\VIP\Logstash\log2logstash(
+		Logger::log2logstash(
 			array(
 				'severity' => 'info',
 				'feature'  => 'search_content_validation',
@@ -132,7 +131,7 @@ class HealthJob {
 
 		$results = $this->health->validate_index_posts_content( [ 'silent' => true ] );
 
-		\Automattic\VIP\Logstash\log2logstash(
+		Logger::log2logstash(
 			array(
 				'severity' => 'info',
 				'feature'  => 'search_content_validation',
@@ -145,6 +144,7 @@ class HealthJob {
 		);
 
 		if ( is_wp_error( $results ) && 'es_content_validation_already_ongoing' !== $results->get_error_code() ) {
+			/** @var WP_Error $results */
 			$message = sprintf( 'Cron validate-contents error for site %d (%s): %s', FILES_CLIENT_SITE_ID, home_url(), $results->get_error_message() );
 			Alerts::chat( '#vip-go-es-alerts', $message, 2 );
 		}

--- a/src/includes/classes/class-logger.php
+++ b/src/includes/classes/class-logger.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace Automattic\VIP\Search;
+
+class Logger {
+	/**
+	 * Adds a log entry.
+	 *
+	 * @param string $level   One of:
+	 *     - 'emergency': System is unusable.
+	 *     - 'alert'    : Action must be taken immediately.
+	 *     - 'critical' : Critical conditions.
+	 *     - 'error'    : Error conditions.
+	 *     - 'warning'  : Warning conditions.
+	 *     - 'notice'   : Normal but significant condition.
+	 *     - 'info'     : Informational messages.
+	 *     - 'debug'    : Debug-level messages.
+	 *
+	 * @param string $feature Log feature; e.g., `my_feature_slug`.
+	 * @param string $message Log message; e.g., `My log message.`.
+	 * @param array  $context Optional. Additional information for log handlers.
+	 */
+	public function log( string $level, string $feature, string $message, array $context = [] ): void {
+		static::log2logstash( [
+			'severity' => $level,
+			'feature'  => $feature,
+			'message'  => $message,
+			'extra'    => $context,
+		] );
+	}
+
+	/**
+	 * Adds an emergency level message.
+	 *
+	 * @param string $feature Log feature; e.g., `my_feature_slug`.
+	 * @param string $message Log message; e.g., `My emergency message.`.
+	 * @param array  $context Optional. Additional information for log handlers.
+	 */
+	public function emergency( string $feature, string $message, array $context = [] ): void {
+		$this->log( __FUNCTION__, $feature, $message, $context );
+	}
+
+	/**
+	 * Adds an alert level message.
+	 *
+	 * @param string $feature Log feature; e.g., `my_feature_slug`.
+	 * @param string $message Log message; e.g., `My alert message.`.
+	 * @param array  $context Optional. Additional information for log handlers.
+	 */
+	public function alert( string $feature, string $message, array $context = [] ): void {
+		$this->log( __FUNCTION__, $feature, $message, $context );
+	}
+
+	/**
+	 * Adds a critical level message.
+	 *
+	 * @param string $feature Log feature; e.g., `my_feature_slug`.
+	 * @param string $message Log message; e.g., `My critical message.`.
+	 * @param array  $context Optional. Additional information for log handlers.
+	 */
+	public function critical( string $feature, string $message, array $context = [] ): void {
+		$this->log( __FUNCTION__, $feature, $message, $context );
+	}
+
+	/**
+	 * Adds an error level message.
+	 *
+	 * @param string $feature Log feature; e.g., `my_feature_slug`.
+	 * @param string $message Log message; e.g., `My error message.`.
+	 * @param array  $context Optional. Additional information for log handlers.
+	 */
+	public function error( string $feature, string $message, array $context = [] ): void {
+		$this->log( __FUNCTION__, $feature, $message, $context );
+	}
+
+	/**
+	 * Adds a warning level message.
+	 *
+	 * @param string $feature Log feature; e.g., `my_feature_slug`.
+	 * @param string $message Log message; e.g., `My warning message.`.
+	 * @param array  $context Optional. Additional information for log handlers.
+	 */
+	public function warning( string $feature, string $message, array $context = [] ): void {
+		$this->log( __FUNCTION__, $feature, $message, $context );
+	}
+
+	/**
+	 * Adds a notice level message.
+	 *
+	 * @param string $feature Log feature; e.g., `my_feature_slug`.
+	 * @param string $message Log message; e.g., `My notice message.`.
+	 * @param array  $context Optional. Additional information for log handlers.
+	 */
+	public function notice( string $feature, string $message, array $context = [] ): void {
+		$this->log( __FUNCTION__, $feature, $message, $context );
+	}
+
+	/**
+	 * Adds a info level message.
+	 *
+	 * @param string $feature Log feature; e.g., `my_feature_slug`.
+	 * @param string $message Log message; e.g., `My info message.`.
+	 * @param array  $context Optional. Additional information for log handlers.
+	 */
+	public function info( string $feature, string $message, array $context = [] ): void {
+		$this->log( __FUNCTION__, $feature, $message, $context );
+	}
+
+	/**
+	 * Adds a debug level message.
+	 *
+	 * @param string $feature Log feature; e.g., `my_feature_slug`.
+	 * @param string $message Log message; e.g., `My debug message.`.
+	 * @param array  $context Optional. Additional information for log handlers.
+	 */
+	public function debug( string $feature, string $message, array $context = [] ): void {
+		$this->log( __FUNCTION__, $feature, $message, $context );
+	}
+
+	public static function log2logstash( array $data ): void {
+		if ( class_exists( \Automattic\VIP\Logstash\Logger::class ) ) {
+			\Automattic\VIP\Logstash\Logger::log2logstash( $data );
+		}
+	}
+
+	public static function process_entries_on_shutdown(): void {
+		if ( class_exists( \Automattic\VIP\Logstash\Logger::class ) ) {
+			\Automattic\VIP\Logstash\Logger::process_entries_on_shutdown();
+		}
+	}
+}

--- a/src/includes/classes/class-queue.php
+++ b/src/includes/classes/class-queue.php
@@ -16,7 +16,7 @@ class Queue {
 	public $schema;
 	/** @var Indexables */
 	public $indexables;
-	/** @var \Automattic\VIP\Logstash\Logger */
+	/** @var Logger */
 	public $logger;
 	/** @var Queue\Cron */
 	public $cron;
@@ -73,7 +73,7 @@ class Queue {
 
 		// Logger - can be set explicitly for mocking purposes
 		if ( ! $this->logger ) {
-			$this->logger = new \Automattic\VIP\Logstash\Logger();
+			$this->logger = new Logger();
 		}
 
 		$this->setup_hooks();
@@ -921,7 +921,7 @@ class Queue {
 				// Increment first to prevent overrunning ratelimiting
 				self::index_count_incr( count( $ids ) );
 
-				\Automattic\VIP\Logstash\log2logstash(
+				Logger::log2logstash(
 					[
 						'severity' => 'info',
 						'feature'  => 'search_queue',
@@ -1139,11 +1139,11 @@ class Queue {
 			$index_limiting_time
 		);
 
-		\Automattic\VIP\Utils\Alerts::instance()->send_to_chat( self::INDEX_RATE_LIMITING_ALERT_SLACK_CHAT, $message, self::INDEX_RATE_LIMITING_ALERT_LEVEL );
+		Alerts::chat( self::INDEX_RATE_LIMITING_ALERT_SLACK_CHAT, $message, self::INDEX_RATE_LIMITING_ALERT_LEVEL );
 
 		trigger_error( $message, \E_USER_WARNING ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 
-		\Automattic\VIP\Logstash\log2logstash(
+		Logger::log2logstash(
 			array(
 				'severity' => 'warning',
 				'feature'  => 'search_indexing_rate_limiting',

--- a/src/includes/classes/class-settingshealthjob.php
+++ b/src/includes/classes/class-settingshealthjob.php
@@ -3,7 +3,6 @@
 namespace Automattic\VIP\Search;
 
 use Automattic\VIP\Search\Health;
-use Automattic\VIP\Utils\Alerts;
 use ElasticPress\Indexable;
 use WP_Error;
 
@@ -124,7 +123,7 @@ class SettingsHealthJob {
 	 */
 	public function check_settings_health() {
 
-		\Automattic\VIP\Logstash\log2logstash(
+		Logger::log2logstash(
 			[
 				'severity' => 'info',
 				'feature'  => 'search_health_job',
@@ -451,7 +450,7 @@ class SettingsHealthJob {
 
 		update_option( self::LAST_PROCESSED_ID_OPTION, 'Indexing completed' );
 
-		\Automattic\VIP\Logstash\log2logstash(
+		Logger::log2logstash(
 			array(
 				'severity' => 'info',
 				'feature'  => 'search_versioning',

--- a/src/includes/classes/class-versioningcleanupjob.php
+++ b/src/includes/classes/class-versioningcleanupjob.php
@@ -133,9 +133,9 @@ class VersioningCleanupJob {
 				$indexable->slug,
 				$delete_version->get_error_message()
 			);
-			\Automattic\VIP\Utils\Alerts::chat( self::SEARCH_ALERT_SLACK_CHAT, $message );
+			Alerts::chat( self::SEARCH_ALERT_SLACK_CHAT, $message );
 		} else {
-			\Automattic\VIP\Logstash\log2logstash(
+			Logger::log2logstash(
 				array(
 					'severity' => 'info',
 					'feature'  => 'search_versioning',

--- a/src/includes/classes/commands/class-corecommand.php
+++ b/src/includes/classes/commands/class-corecommand.php
@@ -2,6 +2,7 @@
 
 namespace Automattic\VIP\Search\Commands;
 
+use Automattic\VIP\Search\Logger;
 use WP_CLI;
 use WP_CLI\Utils;
 use ElasticPress\Elasticsearch;
@@ -298,7 +299,7 @@ class CoreCommand {
 			if ( isset( $assoc_args['setup'] ) && $assoc_args['setup'] ) {
 				self::confirm_destructive_operation( $assoc_args );
 			}
-			
+
 			// Unset our arguments since they don't exist in ElasticPress and causes
 			// an error for indexing operations exclusively for some reason.
 			unset( $assoc_args['version'] );
@@ -308,7 +309,7 @@ class CoreCommand {
 				$assoc_args['yes'] = true;
 			}
 
-			\Automattic\VIP\Logstash\log2logstash(
+			Logger::log2logstash(
 				[
 					'severity' => 'info',
 					'feature'  => 'search_cli',
@@ -388,7 +389,7 @@ class CoreCommand {
 	 * Throw error when delete-index command is attempted to be used.
 	 *
 	 * @subcommand delete-index
-	 * 
+	 *
 	 * @param array $args Positional CLI args.
 	 * @param array $assoc_args Associative CLI args.
 	 */
@@ -542,7 +543,7 @@ class CoreCommand {
 	 * Stop the current indexing operation.
 	 *
 	 * @subcommand stop-indexing
-	 * 
+	 *
 	 * @param array $args Positional CLI args.
 	 * @param array $assoc_args Associative CLI args.
 	 */
@@ -646,7 +647,7 @@ class CoreCommand {
 
 	/**
 	 * Get stats on the current index.
-	 * 
+	 *
 	 * @subcommand stats
 	 */
 	public function get_stats( $args, $assoc_args ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed

--- a/src/includes/classes/commands/class-documentcommand.php
+++ b/src/includes/classes/commands/class-documentcommand.php
@@ -3,15 +3,14 @@
 namespace Automattic\VIP\Search\Commands;
 
 use WP_CLI;
-
-require_once __DIR__ . '/../../../../vip-helpers/vip-wp-cli.php';
+use WP_CLI_Command;
 
 /**
  * Commands to view and manage individual documents
  *
  * @package Automattic\VIP\Search
  */
-class DocumentCommand extends \WPCOM_VIP_CLI_Command {
+class DocumentCommand extends WP_CLI_Command {
 	/**
 	 * Get details about a document by type and an id
 	 *

--- a/src/includes/classes/commands/class-healthcommand.php
+++ b/src/includes/classes/commands/class-healthcommand.php
@@ -3,9 +3,9 @@
 namespace Automattic\VIP\Search\Commands;
 
 use WP_CLI;
+use WP_CLI_Command;
 use WP_Error;
 
-require_once __DIR__ . '/../../../../vip-helpers/vip-wp-cli.php';
 require_once __DIR__ . '/../class-health.php';
 
 /**
@@ -13,7 +13,7 @@ require_once __DIR__ . '/../class-health.php';
  *
  * @package Automattic\VIP\Search
  */
-class HealthCommand extends \WPCOM_VIP_CLI_Command {
+class HealthCommand extends WP_CLI_Command {
 	private const SUCCESS_ICON = "\u{2705}"; // unicode check mark
 	private const FAILURE_ICON = "\u{274C}"; // unicode cross mark
 	private const INFO_ICON    = "\u{1F7E7}"; // unicode info mark
@@ -420,6 +420,7 @@ class HealthCommand extends \WPCOM_VIP_CLI_Command {
 		$results = $health->validate_index_posts_content( $assoc_args );
 
 		if ( is_wp_error( $results ) ) {
+			/** @var WP_Error $results */
 			if ( $results->get_error_code() === 'es_validate_content_aborted' ) {
 				WP_CLI::error( $results->get_error_message() );
 			}

--- a/src/includes/classes/commands/class-queuecommand.php
+++ b/src/includes/classes/commands/class-queuecommand.php
@@ -5,8 +5,8 @@ namespace Automattic\VIP\Search\Commands;
 use WP_CLI;
 
 use Automattic\VIP\Search\Queue\Schema;
+use WP_CLI_Command;
 
-require_once __DIR__ . '/../../../../vip-helpers/vip-wp-cli.php';
 require_once __DIR__ . '/../class-health.php';
 
 /**
@@ -14,7 +14,7 @@ require_once __DIR__ . '/../class-health.php';
  *
  * @package Automattic\VIP\Search
  */
-class QueueCommand extends \WPCOM_VIP_CLI_Command {
+class QueueCommand extends WP_CLI_Command {
 	/**
 	 * Get info on the queue
 	 *

--- a/src/includes/classes/commands/class-versioncommand.php
+++ b/src/includes/classes/commands/class-versioncommand.php
@@ -2,17 +2,17 @@
 
 namespace Automattic\VIP\Search\Commands;
 
-use WP_CLI;
 use ElasticPress\Indexable;
-
-require_once __DIR__ . '/../../../../vip-helpers/vip-wp-cli.php';
+use WP_CLI;
+use WP_CLI_Command;
+use WP_Error;
 
 /**
  * Commands to view and manage index versions
  *
  * @package Automattic\VIP\Search
  */
-class VersionCommand extends \WPCOM_VIP_CLI_Command {
+class VersionCommand extends WP_CLI_Command {
 	/**
 	 * Register a new index version
 	 *
@@ -123,6 +123,7 @@ class VersionCommand extends \WPCOM_VIP_CLI_Command {
 				restore_current_blog();
 
 				if ( is_wp_error( $version ) ) {
+					/** @var WP_Error $version */
 					return WP_CLI::error( sprintf( 'Index version "%s" for type %s is not valid on blog %d: %s', $args[1], $type, $site['blog_id'], $version->get_error_message() ) );
 				}
 
@@ -141,6 +142,7 @@ class VersionCommand extends \WPCOM_VIP_CLI_Command {
 			$version = $search->versioning->get_version( $indexable, $args[1] );
 
 			if ( is_wp_error( $version ) ) {
+				/** @var WP_Error $version */
 				return WP_CLI::error( sprintf( 'Index version "%s" for type %s is not valid: %s', $args[1], $type, $version->get_error_message() ) );
 			}
 
@@ -198,6 +200,7 @@ class VersionCommand extends \WPCOM_VIP_CLI_Command {
 				$site_versions = $search->versioning->get_versions( $indexable );
 
 				if ( is_wp_error( $site_versions ) ) {
+					/** @var WP_Error $site_versions */
 					restore_current_blog();
 					return WP_CLI::error( $site_versions->get_error_message() );
 				}
@@ -223,6 +226,7 @@ class VersionCommand extends \WPCOM_VIP_CLI_Command {
 			}
 
 			if ( is_wp_error( $versions ) ) {
+				/** @var WP_Error $versions */
 				return WP_CLI::error( $versions->get_error_message() );
 			}
 
@@ -464,6 +468,7 @@ class VersionCommand extends \WPCOM_VIP_CLI_Command {
 				$version = $search->versioning->get_version( $indexable, $args[1] );
 
 				if ( is_wp_error( $version ) ) {
+					/** @var WP_Error $version */
 					return WP_CLI::error( sprintf( 'Index version "%s" for type %s is not valid on blog %d: %s', $args[1], $type, $site['blog_id'], $version->get_error_message() ) );
 				}
 
@@ -495,6 +500,7 @@ class VersionCommand extends \WPCOM_VIP_CLI_Command {
 			$version = $search->versioning->get_version( $indexable, $args[1] );
 
 			if ( is_wp_error( $version ) ) {
+				/** @var WP_Error $version */
 				return WP_CLI::error( sprintf( 'Index version "%s" for type %s is not valid: %s', $args[1], $type, $version->get_error_message() ) );
 			}
 

--- a/src/includes/classes/concurrency-limiter/class-object-cache-backend.php
+++ b/src/includes/classes/concurrency-limiter/class-object-cache-backend.php
@@ -2,6 +2,8 @@
 
 namespace Automattic\VIP\Search\ConcurrencyLimiter;
 
+use Automattic\VIP\Search\Logger;
+
 use function Automattic\VIP\Logstash\log2logstash;
 
 require_once __DIR__ . '/backendinterface.php';
@@ -50,7 +52,7 @@ class Object_Cache_Backend implements BackendInterface {
 				++$this->increments;
 
 				if ( $value > $this->limit ) {
-					log2logstash( [
+					Logger::log2logstash( [
 						'severity' => 'warning',
 						'feature'  => 'search_concurrency_limiter',
 						'message'  => 'Reached concurrency limit',
@@ -65,7 +67,7 @@ class Object_Cache_Backend implements BackendInterface {
 			}
 		}
 
-		log2logstash( [
+		Logger::log2logstash( [
 			'severity' => 'warning',
 			'feature'  => 'search_concurrency_limiter',
 			'message'  => 'Failed to increment the counter',
@@ -87,7 +89,7 @@ class Object_Cache_Backend implements BackendInterface {
 					$this->reset();
 				}
 			} else {
-				log2logstash( [
+				Logger::log2logstash( [
 					'severity' => 'warning',
 					'feature'  => 'search_concurrency_limiter',
 					'message'  => 'Failed to decrement the counter',

--- a/src/includes/functions/ep-get-query-log.php
+++ b/src/includes/functions/ep-get-query-log.php
@@ -1,9 +1,6 @@
 <?php
-if ( method_exists( '\Automattic\VIP\Search\Search', 'should_load_new_ep' ) && \Automattic\VIP\Search\Search::should_load_new_ep() ) {
-	require_once __DIR__ . '/../../elasticpress-next/elasticpress.php';
-} else {
-	require_once __DIR__ . '/../../elasticpress/elasticpress.php';
-}
+
+require_once __DIR__ . '/../../elasticpress/elasticpress.php';
 
 // Override query log to remove Authorization header.
 function ep_get_query_log() {

--- a/src/includes/functions/utils.php
+++ b/src/includes/functions/utils.php
@@ -1,6 +1,6 @@
 <?php
 
-use Automattic\VIP\Utils\Alerts;
+use Automattic\VIP\Search\Logger;
 
 /**
  * Wrapper for getting related posts. The feature Related_posts must be active.
@@ -32,7 +32,7 @@ function vip_maybe_backfill_ep_option( $value, $option ) {
 			$home_url = home_url();
 
 			$message = $option_added ? "Successfully added {$option} option to subsite." : "Attempted to add {$option} option to subsite.";
-			\Automattic\VIP\Logstash\log2logstash(
+			Logger::log2logstash(
 				array(
 					'severity' => 'info',
 					'feature'  => 'search_ep_option',

--- a/src/search.php
+++ b/src/search.php
@@ -23,6 +23,8 @@ if ( defined( 'VIP_ELASTICSEARCH_DISABLED' ) && true === constant( 'VIP_ELASTICS
 	return;
 }
 
+require_once __DIR__ . '/includes/classes/class-alerts.php';
+require_once __DIR__ . '/includes/classes/class-logger.php';
 require_once __DIR__ . '/includes/functions/utils.php';
 require_once __DIR__ . '/includes/classes/class-search.php';
 


### PR DESCRIPTION
This PR adds replacements for:
* `\Automattic\VIP\Utils\Alerts` (partial implementation only for the used methods);
* `\Automattic\VIP\Logstash\Logger` (partial implementation);
* `\Automattic\VIP\Logstash\log2logstash()` (replaced with `Logger::log2logstash()`);
* `\Automattic\VIP\Search\Search::should_load_new_ep()` (assume it always returns `true`).

References to `WPCOM_VIP_CLI_Command` are replaced with `WP_CLI_Command` (we don't seem to use any of `WPCOM_VIP_CLI_Command`'s features).

Calls to `vip_reset_local_object_cache()` and `vip_safe_wp_remote_request()` are guarded with `function_exists()`.

A couple of other bugs fixed, see Slack.

