### PR TITLE
refactor: avoid fully-qualified names if possible

### DIFF
--- a/src/includes/classes/class-fieldcountgaugejob.php
+++ b/src/includes/classes/class-fieldcountgaugejob.php
@@ -7,13 +7,13 @@ require_once __DIR__ . '/class-versioningcleanupjob.php';
 class FieldCountGaugeJob {
 	public function init() {
 		// We always add this action so that the job can unregister itself if it no longer should be running
-		add_action( \Automattic\VIP\Search\VersioningCleanupJob::CRON_EVENT_NAME, [ $this, 'maybe_alert_for_field_count' ] );
+		add_action( VersioningCleanupJob::CRON_EVENT_NAME, [ $this, 'maybe_alert_for_field_count' ] );
 	}
 
 	/**
 	 * Set the field count gauge for posts for the current site
 	 */
 	public function maybe_alert_for_field_count() {
-		\Automattic\VIP\Search\Search::instance()->maybe_alert_for_field_count();
+		Search::instance()->maybe_alert_for_field_count();
 	}
 }

--- a/src/includes/classes/class-healthjob.php
+++ b/src/includes/classes/class-healthjob.php
@@ -3,6 +3,7 @@
 namespace Automattic\VIP\Search;
 
 use Automattic\VIP\Search\Health;
+use ElasticPress\Indexables;
 
 require_once __DIR__ . '/class-health.php';
 
@@ -39,7 +40,7 @@ class HealthJob {
 	 *
 	 * Useful for overriding (dependency injection) for tests
 	 *
-	 * @var \Automattic\VIP\Search\Search
+	 * @var Search
 	 */
 	public $search;
 
@@ -48,14 +49,14 @@ class HealthJob {
 	 *
 	 * Useful for overriding (dependency injection) for tests
 	 *
-	 * @var \ElasticPress\Indexables
+	 * @var Indexables
 	 */
 	public $indexables;
 
-	public function __construct( \Automattic\VIP\Search\Search $search ) {
+	public function __construct( Search $search ) {
 		$this->search     = $search;
 		$this->health     = new Health( $search );
-		$this->indexables = \ElasticPress\Indexables::factory();
+		$this->indexables = Indexables::factory();
 	}
 
 	/**

--- a/src/includes/classes/class-queue.php
+++ b/src/includes/classes/class-queue.php
@@ -292,7 +292,7 @@ class Queue {
 				return new WP_Error( 'invalid-indexable', sprintf( 'Indexable not found for type %s', $indexable_slug ) );
 			}
 
-			$index_version = \Automattic\VIP\Search\Search::instance()->versioning->get_current_version_number( $indexable );
+			$index_version = Search::instance()->versioning->get_current_version_number( $indexable );
 		}
 
 		return $index_version;
@@ -908,13 +908,13 @@ class Queue {
 
 				// If the index version no longer exists, just delete the jobs and don't bother with stats or anything
 				// since the jobs weren't actually processed
-				$index_versions = \Automattic\VIP\Search\Search::instance()->versioning->get_versions( $indexable );
+				$index_versions = Search::instance()->versioning->get_versions( $indexable );
 				if ( ! array_key_exists( intval( $index_version ), $index_versions ) ) {
 					$this->delete_jobs( $jobs );
 					continue;
 				}
 
-				\Automattic\VIP\Search\Search::instance()->versioning->set_current_version_number( $indexable, $index_version );
+				Search::instance()->versioning->set_current_version_number( $indexable, $index_version );
 
 				$ids = wp_list_pluck( $jobs, 'object_id' );
 
@@ -942,7 +942,7 @@ class Queue {
 				// Mark them as done in queue
 				$this->delete_jobs( $jobs );
 
-				\Automattic\VIP\Search\Search::instance()->versioning->reset_current_version_number( $indexable );
+				Search::instance()->versioning->reset_current_version_number( $indexable );
 			}
 		}
 	}

--- a/src/includes/classes/class-queuewaittimejob.php
+++ b/src/includes/classes/class-queuewaittimejob.php
@@ -7,13 +7,13 @@ require_once __DIR__ . '/class-settingshealthjob.php';
 class QueueWaitTimeJob {
 	public function init() {
 		// We always add this action so that the job can unregister itself if it no longer should be running
-		add_action( \Automattic\VIP\Search\SettingsHealthJob::CRON_EVENT_NAME, [ $this, 'maybe_alert_for_average_queue_time' ] );
+		add_action( SettingsHealthJob::CRON_EVENT_NAME, [ $this, 'maybe_alert_for_average_queue_time' ] );
 	}
 
 	/**
 	 * Set the queue wait time gauge for posts for the current site
 	 */
 	public function maybe_alert_for_average_queue_time() {
-		\Automattic\VIP\Search\Search::instance()->maybe_alert_for_average_queue_time();
+		Search::instance()->maybe_alert_for_average_queue_time();
 	}
 }

--- a/src/includes/classes/class-search.php
+++ b/src/includes/classes/class-search.php
@@ -2,6 +2,8 @@
 
 namespace Automattic\VIP\Search;
 
+use Automattic\VIP\Search\Commands\CoreCommand;
+use ElasticPress\Command;
 use WP_CLI;
 use WP_Error;
 use WP_Post;
@@ -657,7 +659,7 @@ class Search {
 			WP_CLI::add_command( 'vip-search queue', __NAMESPACE__ . '\Commands\QueueCommand' );
 			WP_CLI::add_command( 'vip-search index-versions', __NAMESPACE__ . '\Commands\VersionCommand' );
 			WP_CLI::add_command( 'vip-search documents', __NAMESPACE__ . '\Commands\DocumentCommand' );
-			$vip_search_core_command = new \Automattic\VIP\Search\Commands\CoreCommand( new \ElasticPress\Command() );
+			$vip_search_core_command = new CoreCommand( new Command() );
 			WP_CLI::add_command( 'vip-search', $vip_search_core_command );
 		}
 	}

--- a/src/includes/classes/class-settingshealthjob.php
+++ b/src/includes/classes/class-settingshealthjob.php
@@ -4,6 +4,7 @@ namespace Automattic\VIP\Search;
 
 use Automattic\VIP\Search\Health;
 use ElasticPress\Indexable;
+use ElasticPress\Indexables;
 use WP_Error;
 
 require_once __DIR__ . '/class-health.php';
@@ -49,7 +50,7 @@ class SettingsHealthJob {
 	 *
 	 * Useful for overriding (dependency injection) for tests
 	 *
-	 * @var \Automattic\VIP\Search\Search
+	 * @var Search
 	 */
 	public $search;
 
@@ -58,7 +59,7 @@ class SettingsHealthJob {
 	 *
 	 * Useful for overriding (dependency injection) for tests
 	 *
-	 * @var \ElasticPress\Indexables
+	 * @var Indexables
 	 */
 	public $indexables;
 
@@ -69,10 +70,10 @@ class SettingsHealthJob {
 	 */
 	public $health_check_disabled_sites = array();
 
-	public function __construct( \Automattic\VIP\Search\Search $search ) {
+	public function __construct( Search $search ) {
 		$this->search     = $search;
 		$this->health     = new Health( $search );
-		$this->indexables = \ElasticPress\Indexables::factory();
+		$this->indexables = Indexables::factory();
 	}
 
 	/**

--- a/src/includes/classes/class-versioning.php
+++ b/src/includes/classes/class-versioning.php
@@ -697,7 +697,7 @@ class Versioning {
 			return new WP_Error( 'failed-to-delete-index', sprintf( 'Failed to delete index version %d for indexable %s from Elasticsearch', $version_number, $indexable->slug ) );
 		}
 
-		\Automattic\VIP\Search\Search::instance()->queue->delete_jobs_for_index_version( $indexable->slug, $version_number );
+		Search::instance()->queue->delete_jobs_for_index_version( $indexable->slug, $version_number );
 
 		unset( $versions[ $version_number ] );
 
@@ -810,7 +810,7 @@ class Versioning {
 			// Other index versions, besides active
 			$inactive_versions = $this->get_inactive_versions( $indexable );
 
-			$queue = \Automattic\VIP\Search\Search::instance()->queue;
+			$queue = Search::instance()->queue;
 
 			// There were changes for active version - now we need to loop over every object that was queued for the active version and replicate that job to the other versions
 			foreach ( $inactive_versions as $version ) {
@@ -856,7 +856,7 @@ class Versioning {
 			return $bail;
 		}
 
-		$queue = \Automattic\VIP\Search\Search::instance()->queue;
+		$queue = Search::instance()->queue;
 
 		foreach ( $inactive_versions as $version ) {
 			$options = array(

--- a/src/includes/classes/commands/class-corecommand.php
+++ b/src/includes/classes/commands/class-corecommand.php
@@ -3,6 +3,7 @@
 namespace Automattic\VIP\Search\Commands;
 
 use Automattic\VIP\Search\Logger;
+use Automattic\VIP\Search\Search;
 use WP_CLI;
 use WP_CLI\Utils;
 use ElasticPress\Elasticsearch;
@@ -43,7 +44,7 @@ class CoreCommand {
 	}
 
 	private function shift_version_after_index( $assoc_args ) {
-		$search = \Automattic\VIP\Search\Search::instance();
+		$search = Search::instance();
 
 		$indexables   = $this->parse_indexables( $assoc_args );
 		$skip_confirm = isset( $assoc_args['skip-confirm'] ) && $assoc_args['skip-confirm'];
@@ -93,7 +94,7 @@ class CoreCommand {
 	}
 
 	private function set_version( $indexable, $version ) {
-		$search = \Automattic\VIP\Search\Search::instance();
+		$search = Search::instance();
 
 		$result = $search->versioning->set_current_version_number( $indexable, $version );
 
@@ -140,7 +141,7 @@ class CoreCommand {
 			}
 
 			if ( $version_number ) {
-				$search = \Automattic\VIP\Search\Search::instance();
+				$search = Search::instance();
 
 				// For each indexable specified, override the version
 				$indexables = $this->parse_indexables( $assoc_args );
@@ -510,7 +511,7 @@ class CoreCommand {
 	 * @subcommand get-last-indexed-post-id
 	 */
 	public function get_last_indexed_post_id( $args, $assoc_args ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
-		$search = \Automattic\VIP\Search\Search::instance();
+		$search = Search::instance();
 
 		$last_id = get_option( $search::LAST_INDEXED_POST_ID_OPTION );
 

--- a/src/includes/classes/commands/class-documentcommand.php
+++ b/src/includes/classes/commands/class-documentcommand.php
@@ -2,6 +2,8 @@
 
 namespace Automattic\VIP\Search\Commands;
 
+use Automattic\VIP\Search\Search;
+use ElasticPress\Indexables;
 use WP_CLI;
 use WP_CLI_Command;
 
@@ -34,9 +36,9 @@ class DocumentCommand extends WP_CLI_Command {
 		$type      = $args[0];
 		$object_id = $args[1];
 
-		\Automattic\VIP\Search\Search::instance();
+		Search::instance();
 
-		$indexable = \ElasticPress\Indexables::factory()->get( $type );
+		$indexable = Indexables::factory()->get( $type );
 
 		if ( ! $indexable ) {
 			return WP_CLI::error( sprintf( 'Indexable %s not found. Is the feature active?', $type ) );

--- a/src/includes/classes/commands/class-healthcommand.php
+++ b/src/includes/classes/commands/class-healthcommand.php
@@ -2,6 +2,9 @@
 
 namespace Automattic\VIP\Search\Commands;
 
+use Automattic\VIP\Search\Health;
+use Automattic\VIP\Search\Search;
+use ElasticPress\Indexables;
 use WP_CLI;
 use WP_CLI_Command;
 use WP_Error;
@@ -30,7 +33,7 @@ class HealthCommand extends WP_CLI_Command {
 	 * @subcommand stop-validate-contents
 	 */
 	public function stop_validate_contents( $args, $assoc_args ) {
-		$health = new \Automattic\VIP\Search\Health( \Automattic\VIP\Search\Search::instance() );
+		$health = new Health( Search::instance() );
 
 		if ( ! $health->is_validate_content_ongoing() ) {
 			WP_CLI::error( 'There is no validate-contents run ongoing' );
@@ -60,7 +63,7 @@ class HealthCommand extends WP_CLI_Command {
 			WP_CLI::error( __( '--format only accepts the following values: table, json, csv, yaml' ) );
 		}
 
-		$search = \Automattic\VIP\Search\Search::instance();
+		$search = Search::instance();
 
 		$search_rate_limited   = $search::is_rate_limited();
 		$indexing_rate_limited = $search->queue->is_indexing_ratelimited();
@@ -108,7 +111,7 @@ class HealthCommand extends WP_CLI_Command {
 	 * @subcommand validate-counts
 	 */
 	public function validate_counts( $args, $assoc_args ) {
-		foreach ( \ElasticPress\Indexables::factory()->get_all( null, true ) as $indexable_slug ) {
+		foreach ( Indexables::factory()->get_all( null, true ) as $indexable_slug ) {
 			$this->validate_indexable_count( $indexable_slug, $assoc_args );
 			WP_CLI::line( '' );
 		}
@@ -194,7 +197,7 @@ class HealthCommand extends WP_CLI_Command {
 	 * @param array $assoc_args CLI arguments
 	 */
 	private function validate_indexable_count( $indexable_slug, $assoc_args ) {
-		$indexable = \ElasticPress\Indexables::factory()->get( $indexable_slug );
+		$indexable = Indexables::factory()->get( $indexable_slug );
 		if ( ! $indexable ) {
 			WP_CLI::line( "Cannot find indexable '$indexable_slug', probably the feature is not enabled\n" );
 			return;
@@ -253,7 +256,7 @@ class HealthCommand extends WP_CLI_Command {
 	 * @param int $version Validate only a specific version instead of all of them
 	 */
 	private function validate_indexable_count_for_site( $indexable_slug, $version = null ) {
-		$search = \Automattic\VIP\Search\Search::instance();
+		$search = Search::instance();
 
 		$versions = [];
 		$results  = [];
@@ -262,7 +265,7 @@ class HealthCommand extends WP_CLI_Command {
 			$versions[] = $version;
 		} else {
 			// Defaults to all versions
-			$indexable = \ElasticPress\Indexables::factory()->get( $indexable_slug );
+			$indexable = Indexables::factory()->get( $indexable_slug );
 
 			if ( ! $indexable ) {
 				WP_CLI::line( "Cannot find indexable '$indexable_slug', probably the feature is not enabled" );
@@ -277,22 +280,22 @@ class HealthCommand extends WP_CLI_Command {
 		foreach ( $versions as $version_number ) {
 			switch ( $indexable_slug ) {
 				case 'post':
-					$results = \Automattic\VIP\Search\Health::validate_index_posts_count( array(
+					$results = Health::validate_index_posts_count( array(
 						'index_version' => $version_number,
 					) );
 					break;
 				case 'user':
-					$results = \Automattic\VIP\Search\Health::validate_index_users_count( array(
+					$results = Health::validate_index_users_count( array(
 						'index_version' => $version_number,
 					) );
 					break;
 				case 'term':
-					$results = \Automattic\VIP\Search\Health::validate_index_terms_count( array(
+					$results = Health::validate_index_terms_count( array(
 						'index_version' => $version_number,
 					) );
 					break;
 				case 'comment':
-					$results = \Automattic\VIP\Search\Health::validate_index_comments_count( array(
+					$results = Health::validate_index_comments_count( array(
 						'index_version' => $version_number,
 					) );
 					break;
@@ -415,7 +418,7 @@ class HealthCommand extends WP_CLI_Command {
 	 * @subcommand validate-contents
 	 */
 	public function validate_contents( $args, $assoc_args ) {
-		$health = new \Automattic\VIP\Search\Health( \Automattic\VIP\Search\Search::instance() );
+		$health = new Health( Search::instance() );
 
 		$results = $health->validate_index_posts_content( $assoc_args );
 

--- a/src/includes/classes/commands/class-queuecommand.php
+++ b/src/includes/classes/commands/class-queuecommand.php
@@ -5,6 +5,7 @@ namespace Automattic\VIP\Search\Commands;
 use WP_CLI;
 
 use Automattic\VIP\Search\Queue\Schema;
+use Automattic\VIP\Search\Search;
 use WP_CLI_Command;
 
 require_once __DIR__ . '/../class-health.php';
@@ -35,7 +36,7 @@ class QueueCommand extends WP_CLI_Command {
 			WP_CLI::error( __( '--format only accepts the following values: table, json, csv, yaml' ) );
 		}
 
-		$search = \Automattic\VIP\Search\Search::instance();
+		$search = Search::instance();
 		$stats  = $search->queue->get_queue_stats();
 		$info   = [
 			[
@@ -67,7 +68,7 @@ class QueueCommand extends WP_CLI_Command {
 			WP_CLI::confirm( 'Are you sure you want to truncate the existing indexing queue? Any items currently queued will be dropped' );
 		}
 
-		$search = \Automattic\VIP\Search\Search::instance();
+		$search = Search::instance();
 		$queue  = $search->queue;
 		$schema = new Schema();
 		$result = $queue->empty_queue();

--- a/src/includes/classes/commands/class-versioncommand.php
+++ b/src/includes/classes/commands/class-versioncommand.php
@@ -2,7 +2,10 @@
 
 namespace Automattic\VIP\Search\Commands;
 
+use Automattic\VIP\Search\Health;
+use Automattic\VIP\Search\Search;
 use ElasticPress\Indexable;
+use ElasticPress\Indexables;
 use WP_CLI;
 use WP_CLI_Command;
 use WP_Error;
@@ -65,7 +68,7 @@ class VersionCommand extends WP_CLI_Command {
 	}
 
 	protected function add_helper( Indexable $indexable ) {
-		$search = \Automattic\VIP\Search\Search::instance();
+		$search = Search::instance();
 
 		$new_version = $search->versioning->add_version( $indexable );
 
@@ -98,7 +101,7 @@ class VersionCommand extends WP_CLI_Command {
 	public function get( $args, $assoc_args ) {
 		$type = $args[0];
 
-		$search = \Automattic\VIP\Search\Search::instance();
+		$search = Search::instance();
 
 		$indexable = \ElasticPress\Indexables::factory()->get( $type );
 
@@ -176,8 +179,8 @@ class VersionCommand extends WP_CLI_Command {
 	public function list( $args, $assoc_args ) {
 		$type = $args[0];
 
-		$search = \Automattic\VIP\Search\Search::instance();
-		$health = new \Automattic\VIP\Search\Health( $search );
+		$search = Search::instance();
+		$health = new Health( $search );
 
 		$indexable = \ElasticPress\Indexables::factory()->get( $type );
 
@@ -317,7 +320,7 @@ class VersionCommand extends WP_CLI_Command {
 	}
 
 	protected function activate_helper( Indexable $indexable, $version_number_to_activate ) {
-		$search = \Automattic\VIP\Search\Search::instance();
+		$search = Search::instance();
 
 		$new_version_number = $search->versioning->normalize_version_number( $indexable, $version_number_to_activate );
 
@@ -364,13 +367,13 @@ class VersionCommand extends WP_CLI_Command {
 			$assoc_args['yes'] = true;
 		}
 
-		$indexable = \ElasticPress\Indexables::factory()->get( $type );
+		$indexable = Indexables::factory()->get( $type );
 
 		if ( ! $indexable ) {
 			return WP_CLI::error( sprintf( 'Indexable %s not found. Is the feature active?', $type ) );
 		}
 
-		$search = \Automattic\VIP\Search\Search::instance();
+		$search = Search::instance();
 
 		if ( isset( $assoc_args['network-wide'] ) && is_multisite() ) {
 			WP_CLI::confirm( sprintf( 'Are you sure you want to deactivate index version %s for type %s on all sites in this network?', $desired_version_number, $type ), $assoc_args );
@@ -445,9 +448,9 @@ class VersionCommand extends WP_CLI_Command {
 	public function delete( $args, $assoc_args ) {
 		$type = $args[0];
 
-		$search = \Automattic\VIP\Search\Search::instance();
+		$search = Search::instance();
 
-		$indexable = \ElasticPress\Indexables::factory()->get( $type );
+		$indexable = Indexables::factory()->get( $type );
 
 		if ( ! $indexable ) {
 			return WP_CLI::error( sprintf( 'Indexable %s not found. Is the feature active?', $type ) );
@@ -512,7 +515,7 @@ class VersionCommand extends WP_CLI_Command {
 				return WP_CLI::error( sprintf( 'Index version %d is active for type %s and cannot be deleted', $version['number'], $type ) );
 			}
 
-			$result = $search->versioning->delete_version( $indexable, $args[1] );
+			$search->versioning->delete_version( $indexable, $args[1] );
 
 			WP_CLI::success( sprintf( 'Successfully deleted index version %d for type %s', $version['number'], $type ) );
 		}

--- a/src/includes/functions/ep-get-query-log.php
+++ b/src/includes/functions/ep-get-query-log.php
@@ -1,10 +1,12 @@
 <?php
 
+use ElasticPress\Elasticsearch;
+
 require_once __DIR__ . '/../../elasticpress/elasticpress.php';
 
 // Override query log to remove Authorization header.
 function ep_get_query_log() {
-	$queries = \ElasticPress\Elasticsearch::factory()->get_query_log();
+	$queries = Elasticsearch::factory()->get_query_log();
 	foreach ( $queries as $index => $query ) {
 		unset( $queries[ $index ]['args']['headers']['Authorization'] );
 	}

--- a/src/search.php
+++ b/src/search.php
@@ -28,8 +28,8 @@ require_once __DIR__ . '/includes/classes/class-logger.php';
 require_once __DIR__ . '/includes/functions/utils.php';
 require_once __DIR__ . '/includes/classes/class-search.php';
 
-if ( \Automattic\VIP\Search\Search::are_es_constants_defined() ) {
-	$search_plugin = \Automattic\VIP\Search\Search::instance();
+if ( Search::are_es_constants_defined() ) {
+	$search_plugin = Search::instance();
 
 	require_once __DIR__ . '/search-dev-tools/search-dev-tools.php';
 


### PR DESCRIPTION
This PR reduces fully-qualified names to shorter versions; this is necessary to make it easier to find dependencies on the VIP code.