### PR TITLE
fix: do not load ES when WP is being installed

### DIFF
--- a/src/search.php
+++ b/src/search.php
@@ -28,7 +28,7 @@ require_once __DIR__ . '/includes/classes/class-logger.php';
 require_once __DIR__ . '/includes/functions/utils.php';
 require_once __DIR__ . '/includes/classes/class-search.php';
 
-if ( Search::are_es_constants_defined() ) {
+if ( Search::are_es_constants_defined() && ! wp_installing() ) {
 	$search_plugin = Search::instance();
 
 	require_once __DIR__ . '/search-dev-tools/search-dev-tools.php';


### PR DESCRIPTION
See: Automattic/vip-go-mu-plugins#5744